### PR TITLE
Removed deprecated method (createJSModules) of React Native 0.47.0

### DIFF
--- a/android/src/main/java/de/bonify/reactnativepiwik/PiwikPackage.java
+++ b/android/src/main/java/de/bonify/reactnativepiwik/PiwikPackage.java
@@ -16,8 +16,7 @@ import java.util.ArrayList;
 
 public class PiwikPackage implements ReactPackage {
 
-
-    @Override
+    // Deprecated from RN 0.47.0
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
Hi,

Due to https://github.com/facebook/react-native/commit/ce6fb337a146e6f261f2afb564aa19363774a7a8 's breaking change, we should remove the deprecated method `createJSModules`.

Thank you.
